### PR TITLE
forcing certain args without args.txt

### DIFF
--- a/1.0.1 ENG.pchtxt
+++ b/1.0.1 ENG.pchtxt
@@ -39,4 +39,16 @@
 005c7808 1f2003d5
 005c7894 1f2003d5
 
+// force -ui_ps4
+@disabled
+001d1b68 0000e0d2
+
+// force -hdtv1080
+@disabled
+001d1a50 0000e0d2
+
+// force -no_npr
+@disabled
+001d1b2c 0000e0d2
+
 @stop


### PR DESCRIPTION
Added patches to forced enable the following commands without needing an args.txt file

-ui_ps4
-hdtv1080
-no_npr