### PR TITLE
Initial porting of patches to 1.0.5

### DIFF
--- a/MEGA39's (JP, CN & TW)/1.0.3 JAP.pchtxt
+++ b/MEGA39's (JP, CN & TW)/1.0.3 JAP.pchtxt
@@ -10,6 +10,10 @@
 @disabled
 00995A74 "rom:/xxxx.txt"
 
+// Disable Hand Scaling
+@disabled
+00164754 58020014
+
 // Disable Lyrics
 @disabled
 00982E13 "xyric.%03zu"
@@ -23,16 +27,12 @@
 @disabled
 00986E6C "rom/av_weight_db.txt"
 
-@flag offset_shift 0
-
 // Enable HachiHachi Flower Fight (618) & Saturation (207)
 @disabled
 0052E66D 950F
 0052E6E9 990F
 0052F4B9 960F
 0052F51D 9A0F
-
-@flag offset_shift 0x100
 
 // Enable Recording (Requires Custom NCA)
 @disabled
@@ -94,9 +94,5 @@
 001E8DA4 40008052 
 009663E0 "lang2/cn"
 0097B3BA "mod_switch_01"
-
-// Disable Hand Scaling
-@disabled
-00164754 58020014
 
 @stop

--- a/MEGA39's (JP, CN & TW)/1.0.4 JAP.pchtxt
+++ b/MEGA39's (JP, CN & TW)/1.0.4 JAP.pchtxt
@@ -10,6 +10,10 @@
 @disabled
 0099FEEA "rom:/xxxx.txt"
 
+// Disable Hand Scaling
+@disabled
+00164DF4 58020014
+
 // Disable Lyrics
 @disabled
 0098D25B "xyric.%03zu"
@@ -19,16 +23,12 @@
 @disabled
 0098D28C "a_solution_scale"
 
-@flag offset_shift 0 
-
 // Enable HachiHachi Flower Fight (618) & Saturation (207)
 @disabled
 0053404D 950F
 005340C9 990F
 00534E99 960F
 00534EFD 9A0F
-
-@flag offset_shift 0x100
 
 // Enable Recording (Requires Custom NCA)
 @disabled
@@ -89,9 +89,5 @@
 @disabled
 005c77c8 1f2003d5
 005c7854 1f2003d5
-
-// Disable Hand Scaling
-@disabled
-00164DF4 58020014
 
 @stop

--- a/MEGA39's (JP, CN & TW)/1.0.5 JAP.pchtxt
+++ b/MEGA39's (JP, CN & TW)/1.0.5 JAP.pchtxt
@@ -1,0 +1,22 @@
+@nsobid-F51A4F345A39903C79BB28CA64C074C1EB19C77F
+
+# Hatsune Miku: Project DIVA MEGA39's v1.0.5 JAP
+# Original patches: CyberKevin - DeathChaos - Nas - Stewie1.0 - SwigS-27 - Skyth
+# IPSwitch patches: CyberKevin - DeathChaos - SwigS-27 - M&M
+
+@flag offset_shift 0x100
+
+// Disable Hand Scaling
+@disabled
+00165344 58020014
+
+// Disable "resolution_scale"
+@disabled
+0098E2CB "a_solution_scale"
+
+// Force English (Requires extra files)
+@disabled
+001EEC44 20008052
+00971775 "lang2/en"
+
+@stop

--- a/Mega Mix (INT)/1.0.1 ENG.pchtxt
+++ b/Mega Mix (INT)/1.0.1 ENG.pchtxt
@@ -10,6 +10,10 @@
 @disabled
 0099FEEA "rom:/xxxx.txt"
 
+// Disable Hand Scaling
+@disabled
+00164E34 58020014
+
 // Disable Lyrics
 @disabled
 0098D25C "xyric.%03zu"
@@ -86,9 +90,5 @@
 @disabled
 005c7808 1f2003d5
 005c7894 1f2003d5
-
-// Disable Hand Scaling
-@disabled
-00164E34 58020014
 
 @stop

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The Korean release of Hatsune Miku: Project DIVA MEGA39's is not supported.
 
 # List of patches avaliable:
 * Disable args.txt
+* Disable Hand Scaling (Used in older PVs)
 * Disable resolution_scale
 * Disable Lyrics
 * Enable HachiHachi Flower Fight (618) & Saturation (207)
@@ -21,7 +22,6 @@ The Korean release of Hatsune Miku: Project DIVA MEGA39's is not supported.
 * No NPR ([Requires Shader Fix](https://drive.google.com/drive/folders/1nmPeK2Pc0NOGCxTX2oyOyXdp5xCoDDyF?usp=sharing))
 * No PV and Copyright Watermark
 * Remove pv_weight limit file call
-* Disable Hand Scaling (Used in older PVs)
 
 # Credits:
 * [CyberKevin](https://github.com/oocyberkevinoo) (IPSwitch Patches, Original Patches)


### PR DESCRIPTION
Only has Disable Hand Scaling, Disable Resolution Scale, and Force English

Also fixes alphabetical order for Disable Hand Scaling (you're welcome @SwigS-27)